### PR TITLE
[Feature] Additional Yaks Added to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,6 @@ $ crystal spec --error-trace
 
 > 🐃 "No yaks were harmed in the making of this repo."
 -Aneurysm9
+
+> 🐃 🐃 🐃 🐃 🐃 🐃 🐃 🐃 "Came here from where_is_x stream. Repo needed more yaks."
+-Verinaut"

--- a/README.md
+++ b/README.md
@@ -76,4 +76,4 @@ $ crystal spec --error-trace
 -Aneurysm9
 
 > 🐃 🐃 🐃 🐃 🐃 🐃 🐃 🐃 "Came here from where_is_x stream. Repo needed more yaks."
--Verinaut"
+-Verinaut


### PR DESCRIPTION
### Problem
There was only a single, lonely yak included in the Readme. Isolating a noble, social animal like the majestic yak is cruel and unusual. 

### Solution
An established heard of local yaks were lured into the Readme file. Initial monitoring seems to indicate that the lone yak has begun to establish relations with the group. 

### Next Steps
Future PRs should be able to fully socialize the poor outcast.